### PR TITLE
[substrait] Substrait to Velox class, change private to protected.

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -63,7 +63,7 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression::IfThen& substraitIfThen,
       const RowTypePtr& inputType);
 
- private:
+ protected:
   /// Convert list literal to ArrayVector.
   ArrayVectorPtr literalsToArrayVector(
       const ::substrait::Expression::Literal& listLiteral);

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -121,7 +121,7 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::RelCommon& relCommon,
       const core::PlanNodePtr& noEmitNode);
 
- private:
+ protected:
   /// Returns unique ID to use for plan node. Produces sequential numbers
   /// starting from zero.
   std::string nextPlanNodeId();


### PR DESCRIPTION
继承velox的SubstraitVeloxPlanConverter开发Flavius的SubstraitVeloxPlanConverter，需要将velox对象中的private:改为protected:使得flavius能够访问其内部的成员方法。