### PR TITLE
Fix: change SubstraitParser to shared_ptr in SubstraitVeloxExprConver…

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -66,6 +66,10 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression::IfThen& substraitIfThen,
       const RowTypePtr& inputType);
 
+  void setSubstraitParser(std::shared_ptr<SubstraitParser> substraitParser) {
+    substraitParser_ = std::move(substraitParser);
+  }
+
  protected:
   /// Convert list literal to ArrayVector.
   ArrayVectorPtr literalsToArrayVector(
@@ -76,7 +80,8 @@ class SubstraitVeloxExprConverter {
 
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.
-  SubstraitParser substraitParser_;
+  std::shared_ptr<SubstraitParser> substraitParser_{
+      std::make_shared<SubstraitParser>()};
 
   /// The map storing the relations between the function id and the function
   /// name.

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -67,6 +67,7 @@ class SubstraitVeloxExprConverter {
       const RowTypePtr& inputType);
 
   void setSubstraitParser(std::shared_ptr<SubstraitParser> substraitParser) {
+    VELOX_CHECK_NOT_NULL(substraitParser, "SubstraitParser cannot be null");
     substraitParser_ = std::move(substraitParser);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new method to allow external configuration of the SubstraitParser.
	- Introduced shared pointer management for SubstraitParser.

- **Refactor**
	- Updated internal object access to use pointer dereference.
	- Modified memory management approach for SubstraitParser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->