### PR TITLE
[FLAVIUS-2840][CN] Add config to control memory pool abort on OOM

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -76,6 +76,14 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static uint64_t memoryPoolReservedCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
+    /// Config to enable/disable reclaiming used memory by aborting memory
+    /// pools.
+    static constexpr std::string_view kReclaimUsedMemoryByAbortEnabled{
+        "reclaim-used-memory-by-abort-enabled"};
+    static constexpr bool kDefaultReclaimUsedMemoryByAbortEnabled{true};
+    static bool reclaimUsedMemoryByAbortEnabled(
+        const std::unordered_map<std::string, std::string>& configs);
+
     /// Specifies the max time to wait for memory reclaim by arbitration. The
     /// memory reclaim might fail if the max time has exceeded. This prevents
     /// the memory arbitration from getting stuck when the memory reclaim waits
@@ -603,6 +611,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   const MemoryArbitrationStateCheckCB arbitrationStateCheckCb_;
   const uint64_t reservedCapacity_;
   const bool checkUsageLeak_;
+  const bool reclaimUsedMemoryByAbortEnabled_;
   const uint64_t maxArbitrationTimeNs_;
   const ArbitrationParticipant::Config participantConfig_;
   const double memoryReclaimThreadsHwMultiplier_;


### PR DESCRIPTION
fix https://github.com/Kasma-Inc/Flavius/issues/2840 https://github.com/Kasma-Inc/Flavius/issues/2814

添加配置项 `reclaim-used-memory-by-abort-enabled` 
- true：遵循存量逻辑，在指定时间内内存不足会通过spill来回收内存，当超过指定时间后，通过abort来回收内存
- false：永远不会通过 abort 来回收内存